### PR TITLE
docs: Fix simple typo, stabilityback -> stability back

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A curated list of awesome curated lists of many topics.
 
 ## Computer management
 
-* [awesome-scalability](https://github.com/binhnguyennus/awesome-scalability) - An up-to-date and curated reading list for designing high scalability, high availability, high stabilityback-end systems.
+* [awesome-scalability](https://github.com/binhnguyennus/awesome-scalability) - An up-to-date and curated reading list for designing high scalability, high availability, high stability back-end systems.
 * [awesome-shell](https://github.com/alebcay/awesome-shell) - Command-line frameworks, toolkits, guides and gizmos.
 * [awesome-sysadmin](https://github.com/kahun/awesome-sysadmin) - Backups, configuration management, DNS, IMAP/POP3, LDAP, monitoring, SSH, statistics, troubleshooting, virtualization, VPN and more.
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `stability back` rather than `stabilityback`.

